### PR TITLE
Support for refresh_token via command line, if not present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 credentials.json
 __pycache__/
 src/test.json
+*.pyc
+/.vscode/*

--- a/src/slack_bot.py
+++ b/src/slack_bot.py
@@ -91,7 +91,7 @@ def handle_command(command, channel):
 
 if __name__ == "__main__":
     if slack_client.rtm_connect(with_team_state=False):
-        print("Starter Bot connected and running!")
+        print("GETSCORE connected and running!")
         # Read bot's user ID by calling Web API method `auth.test`
         starterbot_id = slack_client.api_call("auth.test")["user_id"]
         while True:


### PR DESCRIPTION
This attempts to obtain client_id and client_secret from environment variables. If it cannot, it uses credentials file. If refresh_token is not available on environment variable, then it attempts to obtain it via original command line input, and prints to the console.